### PR TITLE
Add data-driven case and module lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Data
+
+All predefined case sizes and LED modules can be found in the `data/` directory.
+Indoor and outdoor lists are separated to keep layouts organized. Indoor cases
+are split between `standard` and `cut` sizes. These JSON files are imported by
+the layout engines so updates are automatically reflected in the app.

--- a/data/cases/indoor.json
+++ b/data/cases/indoor.json
@@ -1,0 +1,19 @@
+{
+  "standard": [
+    { "width": 1120, "height": 640, "label": "A" },
+    { "width": 1280, "height": 160, "label": "B-H" },
+    { "width": 160, "height": 1280, "label": "B-V" }
+  ],
+  "cut": [
+    { "width": 1120, "height": 320, "label": "A-1/2" },
+    { "width": 1120, "height": 160, "label": "A-1/4" },
+    { "width": 1280, "height": 160 },
+    { "width": 160, "height": 1280 },
+    { "width": 960, "height": 160 },
+    { "width": 640, "height": 160 },
+    { "width": 320, "height": 160 },
+    { "width": 160, "height": 960 },
+    { "width": 160, "height": 640 },
+    { "width": 160, "height": 320 }
+  ]
+}

--- a/data/cases/outdoor.json
+++ b/data/cases/outdoor.json
@@ -1,0 +1,12 @@
+[
+  { "width": 1600, "height": 960 },
+  { "width": 1600, "height": 640 },
+  { "width": 1600, "height": 320 },
+  { "width": 1280, "height": 960 },
+  { "width": 1280, "height": 640 },
+  { "width": 1280, "height": 320 },
+  { "width": 960, "height": 960 },
+  { "width": 960, "height": 640 },
+  { "width": 960, "height": 320 },
+  { "width": 640, "height": 320 }
+]

--- a/data/led-modules/indoor.json
+++ b/data/led-modules/indoor.json
@@ -1,0 +1,4 @@
+[
+  { "width": 320, "height": 160, "label": "standard" },
+  { "width": 160, "height": 320, "label": "rotated" }
+]

--- a/data/led-modules/outdoor.json
+++ b/data/led-modules/outdoor.json
@@ -1,0 +1,3 @@
+[
+  { "width": 320, "height": 320, "label": "outdoor-standard", "watt": 750 }
+]

--- a/src/components/Dashboard/tools/OutdoorOptimizer.jsx
+++ b/src/components/Dashboard/tools/OutdoorOptimizer.jsx
@@ -9,7 +9,7 @@ import {
 import { Input } from "@/components/Dashboard/ui/input"
 import { validateScreenDimensions } from "@/lib/InputHandler"
 import { RenderCell } from "@/lib/CaseRenderer"
-import { computeOutdoorLayout } from "@/lib/OutdoorLayoutEngine"
+import { computeOutdoorLayout, OUTDOOR_LED_MODULE } from "@/lib/OutdoorLayoutEngine"
 
 export function OutdoorOptimizer() {
   const [screenWidth, setScreenWidth] = useState(2880)
@@ -71,8 +71,8 @@ export function OutdoorOptimizer() {
                 key={i}
                 cell={cell}
                 scale={scale}
-                moduleWidth={cell.width}
-                moduleHeight={cell.height}
+                moduleWidth={OUTDOOR_LED_MODULE.width}
+                moduleHeight={OUTDOOR_LED_MODULE.height}
                 fillColor="green"
               />
             ))}

--- a/src/lib/OptimizerCore.js
+++ b/src/lib/OptimizerCore.js
@@ -1,8 +1,11 @@
 // /lib/OptimizerCore.js
 
+import indoorModules from '../../data/led-modules/indoor.json';
+import indoorCases from '../../data/cases/indoor.json';
+
 // === LED MODULE CONFIG ===
-export const LED_STANDARD = { width: 320, height: 160 };
-export const LED_ROTATED = { width: 160, height: 320 };
+export const LED_STANDARD = indoorModules.find(m => m.label === 'standard');
+export const LED_ROTATED = indoorModules.find(m => m.label === 'rotated');
 
 // === CASE SIZES ===
 export const STANDARD_CASE_WIDTH = 1120;
@@ -48,31 +51,33 @@ export function computeAdvancedLayout(screenWidth, screenHeight) {
     warning: null
   };
 
-  const CASE_A = { width: 1120, height: 640, label: 'A' };
-  const SLICED_A_HALF = { width: 1120, height: 320, label: 'A-1/2' };
-  const SLICED_A_THIRD = { width: 1120, height: 160, label: 'A-1/4' };
-  const CASE_B_H = { width: 1280, height: 160, label: 'B-H' };
-  const CASE_B_V = { width: 160, height: 1280, label: 'B-V' };
+  const CASE_A = indoorCases.standard.find(c => c.label === 'A');
+  const SLICED_A_HALF = indoorCases.cut.find(c => c.label === 'A-1/2');
+  const SLICED_A_THIRD = indoorCases.cut.find(c => c.label === 'A-1/4');
+  const CASE_B_H = indoorCases.standard.find(c => c.label === 'B-H');
+  const CASE_B_V = indoorCases.standard.find(c => c.label === 'B-V');
 
-  const bigCutSizes = [
-    { width: 1280, height: 160 },
-    { width: 160, height: 1280 },
-    { width: 1120, height: 320 },
-    { width: 1120, height: 160 },
-    { width: 960, height: 160 },
-    { width: 640, height: 160 }
-  ];
+  const bigCutSizes = indoorCases.cut.filter(c =>
+    [
+      '1280x160',
+      '160x1280',
+      '1120x320',
+      '1120x160',
+      '960x160',
+      '640x160'
+    ].includes(`${c.width}x${c.height}`)
+  );
 
-  const smallTileSizes = [
-    { width: 320, height: 160 }
-  ];
+  const smallTileSizes = indoorCases.cut.filter(c => c.width === 320 && c.height === 160);
 
-  const offsetSizes = [
-    { width: 160, height: 960 },
-    { width: 160, height: 640 },
-    { width: 160, height: 320 },
-    { width: 320, height: 160 }
-  ];
+  const offsetSizes = indoorCases.cut.filter(c =>
+    [
+      '160x960',
+      '160x640',
+      '160x320',
+      '320x160'
+    ].includes(`${c.width}x${c.height}`)
+  );
 
   // === PHASE 1: Standard placements
   const fullA = placeRectBlocks(CASE_A, screenWidth, screenHeight, [], 'standard');

--- a/src/lib/OutdoorLayoutEngine.js
+++ b/src/lib/OutdoorLayoutEngine.js
@@ -1,15 +1,8 @@
-export const OUTDOOR_CASE_SIZES = [
-  { width: 1600, height: 960 },
-  { width: 1600, height: 640 },
-  { width: 1600, height: 320 },
-  { width: 1280, height: 960 },
-  { width: 1280, height: 640 },
-  { width: 1280, height: 320 },
-  { width: 960, height: 960 },
-  { width: 960, height: 640 },
-  { width: 960, height: 320 },
-  { width: 640, height: 320 }
-];
+import outdoorCases from '../../data/cases/outdoor.json';
+import outdoorModules from '../../data/led-modules/outdoor.json';
+
+export const OUTDOOR_CASE_SIZES = outdoorCases;
+export const OUTDOOR_LED_MODULE = outdoorModules[0];
 
 export function computeOutdoorLayout(screenWidth, screenHeight) {
   const layout = {


### PR DESCRIPTION
## Summary
- wire layout engines to JSON definitions
- expose outdoor LED module to components
- update README on data import mechanism
- set outdoor module to 320x320 @750W

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686bd62470d8832ba51464ac548bb8c4