### PR TITLE
Fix layout sweeping loops

### DIFF
--- a/src/components/Dashboard/tools/IndoorOptimizer.jsx
+++ b/src/components/Dashboard/tools/IndoorOptimizer.jsx
@@ -181,7 +181,7 @@ export function IndoorOptimizer() {
               <CardContent className="text-center">
                 <p className="text-2xl font-bold">{consumption.toFixed(2)} W</p>
                 <p className="text-sm text-muted-foreground">
-                  Area =  {areaM2} m²
+                 {areaM2} m² at {moduleObj.wattPerM2} W/m²
                 </p>
               </CardContent>
             </Card>
@@ -196,7 +196,7 @@ export function IndoorOptimizer() {
                   {totalModules.toFixed(1)}
                 </p>
                 <p className="text-sm text-muted-foreground">
-                  Modules placés
+                 {moduleObj.name}
                 </p>
               </CardContent>
             </Card>

--- a/src/lib/OptimizerCore.js
+++ b/src/lib/OptimizerCore.js
@@ -147,8 +147,8 @@ function gridSweepFiller(cutCases, occupied, maxW, maxH, cutSizes, moduleW, modu
   const isOccupied = (x, y, w, h) =>
     occupied.some((cell) => x < cell.x + cell.width && x + w > cell.x && y < cell.y + cell.height && y + h > cell.y);
 
-  for (let y = 0; y + minH <= maxH; y += minH) {
-    for (let x = 0; x + minW <= maxW;) {
+  for (let y = 0; y < maxH; y += minH) {
+    for (let x = 0; x < maxW;) {
       let placed = false;
       for (let block of cutSizes) {
         const { width, height } = block;
@@ -182,8 +182,8 @@ function gridOffsetSweepFiller(cutCases, occupied, maxW, maxH, offsetSizes, modu
   const isOccupied = (x, y, w, h) =>
     occupied.some((cell) => x < cell.x + cell.width && x + w > cell.x && y < cell.y + cell.height && y + h > cell.y);
 
-  for (let y = 0; y <= maxH - stepY; y += stepY) {
-    for (let x = 0; x <= maxW - stepX; x += stepX) {
+  for (let y = 0; y < maxH; y += stepY) {
+    for (let x = 0; x < maxW; x += stepX) {
       for (let block of offsetSizes) {
         const { width, height } = block;
         if (x + width <= maxW && y + height <= maxH && !isOccupied(x, y, width, height)) {


### PR DESCRIPTION
## Summary
- ensure grid sweep and offset sweep loops iterate over full screen

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ead2d491c832bb9a481bf1f9ca123